### PR TITLE
Fix namespace struct name typo

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -5,7 +5,7 @@ use anyhow::bail;
 use crate::{
     elab,
     expr::{self, Expr},
-    parse::{AxiomInfo, ConstInfo, Nasmespace, TokenTable},
+    parse::{AxiomInfo, ConstInfo, Namespace, TokenTable},
     print::{OpTable, Pretty},
     proof::{self, Axiom},
     tt::{
@@ -258,7 +258,7 @@ pub struct ClassInstanceLemma {
 #[derive(Debug, Clone, Default)]
 pub struct Eval {
     pub tt: TokenTable,
-    pub ns: Nasmespace,
+    pub ns: Namespace,
     pub pp: OpTable,
     pub local_type_consts: Vec<Name>,
     pub type_const_table: HashMap<Name, Kind>,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -149,7 +149,7 @@ pub struct ConstInfo {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct Nasmespace {
+pub struct Namespace {
     pub type_consts: HashSet<Name>,
     pub consts: HashMap<Name, ConstInfo>,
     pub axioms: HashMap<Name, AxiomInfo>,
@@ -162,7 +162,7 @@ pub struct Nasmespace {
 pub struct Parser<'a> {
     lex: &'a mut Lex,
     tt: &'a TokenTable,
-    ns: &'a Nasmespace,
+    ns: &'a Namespace,
     type_locals: Vec<Name>,
     locals: Vec<Name>,
     holes: Vec<(Name, Type)>,
@@ -172,7 +172,7 @@ impl<'a> Parser<'a> {
     pub fn new(
         lex: &'a mut Lex,
         tt: &'a TokenTable,
-        ns: &'a Nasmespace,
+        ns: &'a Namespace,
         type_variables: Vec<Name>,
     ) -> Self {
         Self {


### PR DESCRIPTION
## Summary
- rename `Nasmespace` struct to `Namespace`
- update all references

## Testing
- `cargo check --offline` *(fails: no matching package named `env_logger` found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e041c03c8331b98aad1bdcee9467