### PR TITLE
Switch to namespace blocks and scoped use

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -275,7 +275,7 @@ impl Iterator for Lex {
                     }
                     "infixr" | "nofix" | "infixl" | "infix" | "prefix" | "axiom" | "def"
                     | "lemma" | "const" | "type" | "local" | "inductive" | "structure"
-                    | "instance" | "class" => {
+                    | "instance" | "class" | "namespace" | "use" => {
                         kind = TokenKind::Keyword;
                     }
                     _ => {


### PR DESCRIPTION
## Summary
- require `namespace` commands to use `{ … }` blocks and implicitly close when encountering `}`
- replace the old `import` command with `use`, tracking scoped aliases for values, theorems, and types alongside namespace imports
- extend parser and evaluator state to keep per-namespace `use` entries so references inside a block resolve through new aliases

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d2fe40f6bc833191ef907a6acb3669