### PR TITLE
Refactor declaration ordering to keep primary fields first

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -216,8 +216,8 @@ pub struct CmdLemma {
 #[derive(Clone, Debug)]
 pub struct CmdConst {
     pub id: GlobalId,
-    pub local_classes: Vec<Class>,
     pub local_types: Vec<LocalType>,
+    pub local_classes: Vec<Class>,
     pub ty: Type,
 }
 
@@ -237,8 +237,8 @@ pub struct CmdTypeDef {
 #[derive(Clone, Debug)]
 pub struct CmdTypeInductive {
     pub id: GlobalId,
-    pub this_name: Name,
     pub this: Id,
+    pub this_name: Name,
     pub local_types: Vec<LocalType>,
     pub ind_id: GlobalId,
     pub rec_id: GlobalId,
@@ -247,8 +247,8 @@ pub struct CmdTypeInductive {
 
 #[derive(Clone, Debug)]
 pub struct TypeInductiveConstructor {
-    pub name: Name,
     pub ctor_id: GlobalId,
+    pub name: Name,
     pub ctor_spec_id: GlobalId,
     pub ty: Type,
 }
@@ -256,8 +256,8 @@ pub struct TypeInductiveConstructor {
 #[derive(Clone, Debug)]
 pub struct CmdInductive {
     pub id: GlobalId,
-    pub this_name: Name,
     pub this: Id,
+    pub this_name: Name,
     pub local_types: Vec<LocalType>,
     pub params: Vec<Local>,
     pub target_ty: Type,
@@ -267,8 +267,8 @@ pub struct CmdInductive {
 
 #[derive(Clone, Debug)]
 pub struct InductiveConstructor {
-    pub name: Name,
     pub ctor_id: GlobalId,
+    pub name: Name,
     pub target: Term,
 }
 
@@ -296,8 +296,8 @@ pub struct StructureConst {
 
 #[derive(Clone, Debug)]
 pub struct StructureAxiom {
-    pub field_name: Name,
     pub id: GlobalId,
+    pub field_name: Name,
     pub target: Term,
 }
 
@@ -360,8 +360,8 @@ pub struct ClassStructureConst {
 
 #[derive(Clone, Debug)]
 pub struct ClassStructureAxiom {
-    pub field_name: Name,
     pub id: GlobalId,
+    pub field_name: Name,
     pub target: Term,
 }
 
@@ -1448,8 +1448,8 @@ impl Eval {
     fn run_type_inductive_cmd(&mut self, cmd: CmdTypeInductive) -> anyhow::Result<()> {
         let CmdTypeInductive {
             id,
-            this_name,
             this,
+            this_name,
             local_types,
             ind_id,
             rec_id,
@@ -1783,8 +1783,8 @@ impl Eval {
         //
         let CmdInductive {
             id,
-            this_name,
             this,
+            this_name,
             local_types,
             params,
             target_ty,
@@ -2068,8 +2068,8 @@ impl Eval {
                     });
                 }
                 StructureField::Axiom(StructureAxiom {
-                    field_name,
                     id,
+                    field_name,
                     target,
                 }) => {
                     let field_name = field_name.clone();
@@ -2571,8 +2571,8 @@ impl Eval {
                     });
                 }
                 ClassStructureField::Axiom(ClassStructureAxiom {
-                    field_name,
                     id,
+                    field_name,
                     target,
                 }) => {
                     let field_name = field_name.clone();
@@ -3095,14 +3095,14 @@ mod tests {
 
         eval.run_cmd(Cmd::TypeInductive(CmdTypeInductive {
             id: global_id("foo"),
-            this_name: Name::from_str("foo"),
             this,
+            this_name: Name::from_str("foo"),
             local_types: vec![],
             ind_id: ind_id.clone(),
             rec_id: rec_id.clone(),
             ctors: vec![TypeInductiveConstructor {
-                name: Name::from_str("mk"),
                 ctor_id: ctor_id.clone(),
+                name: Name::from_str("mk"),
                 ctor_spec_id: ctor_spec_id.clone(),
                 ty: mk_type_local(this),
             }],
@@ -3130,15 +3130,15 @@ mod tests {
 
         eval.run_cmd(Cmd::Inductive(CmdInductive {
             id: global_id("foo"),
-            this_name: Name::from_str("foo"),
             this,
+            this_name: Name::from_str("foo"),
             local_types: vec![],
             params: vec![],
             target_ty: mk_type_prop(),
             ind_id: ind_id.clone(),
             ctors: vec![InductiveConstructor {
-                name: Name::from_str("mk"),
                 ctor_id: ctor_id.clone(),
+                name: Name::from_str("mk"),
                 target: mk_local(this),
             }],
         }))

--- a/src/elab.rs
+++ b/src/elab.rs
@@ -743,8 +743,8 @@ impl<'a> Elaborator<'a> {
                 for field in &*fields {
                     match field {
                         LocalStructureField::Const(LocalStructureConst {
-                            field_name,
                             field_id,
+                            field_name,
                             id,
                             ty: field_ty,
                             ..
@@ -811,9 +811,9 @@ impl<'a> Elaborator<'a> {
                 for field in &*fields {
                     match field {
                         LocalStructureField::Const(LocalStructureConst {
-                            name,
                             field_id,
                             id,
+                            name,
                             ty,
                             ..
                         }) => {
@@ -847,8 +847,8 @@ impl<'a> Elaborator<'a> {
                 for field in &*fields {
                     match field {
                         LocalStructureField::Const(LocalStructureConst {
-                            field_name,
                             field_id,
+                            field_name,
                             id,
                             ty,
                             ..

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -202,8 +202,8 @@ pub enum ParseError {
 
 #[derive(Debug, Clone)]
 struct LocalConst {
-    name: QualifiedName,
     id: Id,
+    name: QualifiedName,
 }
 
 #[derive(Debug, Clone)]
@@ -214,8 +214,8 @@ struct LocalAxiom {
 
 #[derive(Debug, Clone)]
 struct LocalBinding {
-    name: Name,
     id: Id,
+    name: Name,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -395,7 +395,7 @@ impl<'a> Parser<'a> {
     }
 
     fn push_local_const(&mut self, name: QualifiedName, id: Id) {
-        self.local_consts.push(LocalConst { name, id });
+        self.local_consts.push(LocalConst { id, name });
     }
 
     fn push_local_axiom(&mut self, name: QualifiedName, id: Id, target: Term) {
@@ -1632,10 +1632,10 @@ impl<'a> Parser<'a> {
                             .join("."),
                     );
                     fields.push(LocalStructureField::Const(LocalStructureConst {
-                        field_name,
-                        name,
                         field_id: bare_id,
                         id,
+                        field_name,
+                        name,
                         ty: field_ty,
                     }));
                     num_consts += 1;
@@ -1656,8 +1656,8 @@ impl<'a> Parser<'a> {
                             id: {
                                 let id = Id::fresh();
                                 self.locals.push(LocalBinding {
-                                    name: param_name.clone(),
                                     id,
+                                    name: param_name.clone(),
                                 });
                                 id
                             },
@@ -1671,8 +1671,8 @@ impl<'a> Parser<'a> {
                     target = generalize(&target, &params);
                     let id = Id::fresh();
                     fields.push(LocalStructureField::Axiom(LocalStructureAxiom {
-                        field_name,
                         id,
+                        field_name,
                         target,
                     }))
                 }
@@ -1684,8 +1684,8 @@ impl<'a> Parser<'a> {
 
         let structure_id = Id::fresh();
         self.local_types.push(LocalBinding {
-            name: name.clone(),
             id: structure_id,
+            name: name.clone(),
         });
         let this_ty = mk_type_local(structure_id);
         let this = Local {
@@ -1699,24 +1699,24 @@ impl<'a> Parser<'a> {
         for field in &fields {
             match field {
                 LocalStructureField::Const(LocalStructureConst {
-                    field_name,
                     field_id,
+                    field_name,
                     id,
                     ty: _,
                     ..
                 }) => {
                     let fullname = structure_name.extend(field_name.clone());
                     local_consts.push(LocalConst {
-                        name: fullname.clone(),
                         id: *id,
+                        name: fullname.clone(),
                     });
                     let mut target = mk_local(*id);
                     target = target.apply([mk_local(this.id)]);
                     subst.push((*field_id, target));
                 }
                 LocalStructureField::Axiom(LocalStructureAxiom {
-                    field_name,
                     id,
+                    field_name,
                     target,
                 }) => {
                     let fullname = structure_name.extend(field_name.clone());
@@ -2551,8 +2551,8 @@ impl<'a> Parser<'a> {
             .map(|name| {
                 let id = Id::fresh();
                 self.local_types.push(LocalBinding {
-                    name: name.clone(),
                     id,
+                    name: name.clone(),
                 });
                 LocalType {
                     id,
@@ -2758,12 +2758,12 @@ impl<'a> Parser<'a> {
             }
             let id = Id::fresh();
             self.local_types.push(LocalBinding {
-                name: local_type.clone(),
                 id,
+                name: local_type.clone(),
             });
             local_types.push(LocalBinding {
-                name: local_type,
                 id,
+                name: local_type,
             });
         }
         self.expect_symbol(":=")?;
@@ -2813,10 +2813,10 @@ impl<'a> Parser<'a> {
             }
             let id = Id::fresh();
             self.local_types.push(LocalBinding {
-                name: tv.clone(),
                 id,
+                name: tv.clone(),
             });
-            local_types.push(LocalBinding { name: tv, id });
+            local_types.push(LocalBinding { id, name: tv });
         }
         let mut ctors: Vec<TypeInductiveConstructor> = vec![];
         while let Some(_token) = self.expect_symbol_opt("|") {
@@ -2830,8 +2830,8 @@ impl<'a> Parser<'a> {
             self.expect_symbol(":")?;
             let ty = self.ty()?;
             ctors.push(TypeInductiveConstructor {
-                name: ctor_name.clone(),
                 ctor_id: name.clone().extend(ctor_name.clone()).to_global_id(),
+                name: ctor_name.clone(),
                 ctor_spec_id: name
                     .clone()
                     .extend(ctor_name.clone())
@@ -2848,8 +2848,8 @@ impl<'a> Parser<'a> {
         let rec_id = name.extend(Name::from_str("rec")).to_global_id();
         Ok(CmdTypeInductive {
             id,
-            this_name,
             this,
+            this_name,
             local_types: local_types
                 .iter()
                 .map(|binding| LocalType {
@@ -2886,7 +2886,7 @@ impl<'a> Parser<'a> {
             .into_iter()
             .map(|name| {
                 let id = Id::fresh();
-                self.local_types.push(LocalBinding { name, id });
+                self.local_types.push(LocalBinding { id, name });
                 LocalType {
                     id,
                     name: Some(
@@ -2907,8 +2907,8 @@ impl<'a> Parser<'a> {
                 id: {
                     let id = Id::fresh();
                     self.locals.push(LocalBinding {
-                        name: param_name.clone(),
                         id,
+                        name: param_name.clone(),
                     });
                     id
                 },
@@ -2935,8 +2935,8 @@ impl<'a> Parser<'a> {
                     id: {
                         let id = Id::fresh();
                         self.locals.push(LocalBinding {
-                            name: ctor_param_name.clone(),
                             id,
+                            name: ctor_param_name.clone(),
                         });
                         id
                     },
@@ -2949,8 +2949,8 @@ impl<'a> Parser<'a> {
             self.locals.truncate(ctor_params_start);
             target = generalize(&target, &ctor_params);
             ctors.push(InductiveConstructor {
-                name: ctor_name.clone(),
                 ctor_id: name.clone().extend(ctor_name.clone()).to_global_id(),
+                name: ctor_name.clone(),
                 target,
             })
         }
@@ -2962,13 +2962,13 @@ impl<'a> Parser<'a> {
         let ind_id = name.extend(Name::from_str("ind")).to_global_id();
         Ok(CmdInductive {
             id,
-            this_name,
             this,
+            this_name,
             local_types,
-            ctors,
             params,
             target_ty,
             ind_id,
+            ctors,
         })
     }
 
@@ -3043,8 +3043,8 @@ impl<'a> Parser<'a> {
                     let field_qualified_name =
                         name.clone().extend(field_name.clone()).to_global_id();
                     fields.push(StructureField::Axiom(StructureAxiom {
-                        field_name,
                         id: field_qualified_name,
+                        field_name,
                         target,
                     }))
                 }
@@ -3308,8 +3308,8 @@ impl<'a> Parser<'a> {
                     let field_qualified_name =
                         name.clone().extend(field_name.clone()).to_global_id();
                     fields.push(ClassStructureField::Axiom(ClassStructureAxiom {
-                        field_name,
                         id: field_qualified_name,
+                        field_name,
                         target,
                     }))
                 }
@@ -6365,8 +6365,8 @@ mod tests {
         .expect("type inductive command parses");
         let Cmd::TypeInductive(CmdTypeInductive {
             id,
-            this_name,
             this,
+            this_name,
             local_types,
             ind_id,
             rec_id,
@@ -6383,8 +6383,8 @@ mod tests {
         assert_ne!(this, local_types[0].id);
         let [
             TypeInductiveConstructor {
-                name,
                 ctor_id,
+                name,
                 ctor_spec_id,
                 ty,
             },
@@ -6417,8 +6417,8 @@ mod tests {
         .expect("inductive command parses");
         let Cmd::Inductive(CmdInductive {
             id,
-            this_name,
             this,
+            this_name,
             local_types,
             params,
             target_ty,
@@ -6436,8 +6436,8 @@ mod tests {
         assert_eq!(target_ty, mk_type_prop());
         let [
             InductiveConstructor {
-                name,
                 ctor_id,
+                name,
                 target,
             },
         ] = ctors.as_slice()

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -291,17 +291,17 @@ pub enum LocalStructureField {
 
 #[derive(Debug, Clone)]
 pub struct LocalStructureConst {
-    pub field_name: Name,
-    pub name: Name,
     pub field_id: Id,
+    pub field_name: Name,
     pub id: Id,
+    pub name: Name,
     pub ty: Type,
 }
 
 #[derive(Debug, Clone)]
 pub struct LocalStructureAxiom {
-    pub field_name: Name,
     pub id: Id,
+    pub field_name: Name,
     pub target: Term,
 }
 
@@ -1274,8 +1274,8 @@ impl Env<'_> {
                 for field in fields {
                     match field {
                         LocalStructureField::Const(LocalStructureConst {
-                            field_name,
                             field_id,
+                            field_name,
                             id,
                             ty: field_ty,
                             ..
@@ -1322,9 +1322,9 @@ impl Env<'_> {
                 for field in fields {
                     match field {
                         LocalStructureField::Const(LocalStructureConst {
-                            name,
                             field_id,
                             id,
+                            name,
                             ty,
                             ..
                         }) => {
@@ -1358,8 +1358,8 @@ impl Env<'_> {
                 for field in fields {
                     match field {
                         LocalStructureField::Const(LocalStructureConst {
-                            field_name,
                             field_id,
+                            field_name,
                             id,
                             ty,
                             ..

--- a/src/tt.rs
+++ b/src/tt.rs
@@ -1742,8 +1742,8 @@ impl Term {
 pub struct LocalEnv {
     pub local_types: Vec<LocalType>,
     pub local_classes: Vec<Class>,
-    pub local_deltas: Vec<LocalDelta>,
     pub locals: Vec<Local>,
+    pub local_deltas: Vec<LocalDelta>,
 }
 
 impl LocalEnv {

--- a/tests/source_layout.rs
+++ b/tests/source_layout.rs
@@ -1,0 +1,81 @@
+use std::fs;
+
+#[test]
+fn declarations_keep_primary_fields_before_auxiliary_fields() {
+    let cmd = read("src/cmd.rs");
+    assert_struct_fields(
+        &cmd,
+        "CmdConst",
+        &["id", "local_types", "local_classes", "ty"],
+    );
+    assert_struct_fields(
+        &cmd,
+        "CmdTypeInductive",
+        &[
+            "id",
+            "this",
+            "this_name",
+            "local_types",
+            "ind_id",
+            "rec_id",
+            "ctors",
+        ],
+    );
+    assert_struct_fields(&cmd, "StructureAxiom", &["id", "field_name", "target"]);
+    assert_struct_fields(&cmd, "ClassStructureAxiom", &["id", "field_name", "target"]);
+
+    let proof = read("src/proof.rs");
+    assert_struct_fields(
+        &proof,
+        "LocalStructureConst",
+        &["field_id", "field_name", "id", "name", "ty"],
+    );
+    assert_struct_fields(
+        &proof,
+        "LocalStructureAxiom",
+        &["id", "field_name", "target"],
+    );
+
+    let parse = read("src/parse.rs");
+    assert_struct_fields(&parse, "LocalConst", &["id", "name"]);
+    assert_struct_fields(&parse, "LocalBinding", &["id", "name"]);
+
+    let tt = read("src/tt.rs");
+    assert_struct_fields(
+        &tt,
+        "LocalEnv",
+        &["local_types", "local_classes", "locals", "local_deltas"],
+    );
+}
+
+fn assert_struct_fields(text: &str, name: &str, expected: &[&str]) {
+    let body = struct_body(text, name);
+    let actual = body.lines().filter_map(field_name).collect::<Vec<_>>();
+    assert_eq!(actual, expected, "{name} field order changed");
+}
+
+fn struct_body<'a>(text: &'a str, name: &str) -> &'a str {
+    let marker = format!("struct {name} {{");
+    let start = text
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing struct {name}"));
+    let rest = &text[start + marker.len()..];
+    let end = rest
+        .find("\n}")
+        .unwrap_or_else(|| panic!("missing closing brace for {name}"));
+    &rest[..end]
+}
+
+fn field_name(line: &str) -> Option<&str> {
+    let line = line.trim();
+    if !line.starts_with("pub ") && !line.contains(':') {
+        return None;
+    }
+    let line = line.strip_prefix("pub ").unwrap_or(line);
+    let (name, _) = line.split_once(':')?;
+    Some(name.trim())
+}
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}


### PR DESCRIPTION
## Summary
- reorder AST and parser-related struct fields so primary identifiers appear before auxiliary names and related fields stay adjacent
- update matching destructuring and constructors across parsing, elaboration, proof, and command code to follow the new declaration order
- add a source-layout test to lock the intended field ordering for representative structs

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test --all --all-features --locked`